### PR TITLE
Exploration 1: using `useDispatch` and `useSelector` hooks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,68 +1,11 @@
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+# redux-toolkit-workshop-playground
+## Exploration 1:
 
-## Available Scripts
+Some thoughts and opinions
+- This introduces the need of shadowing names, or coming up with different (but similar ones)
+- You cannot hook your HTML elements events into a useDispatch: the event param contains non-serializable properties and Redux Toolkit will drop errors in your console
+  - This could be fixed by creating a `useDispatch()` abstraction but that feels extra work to do (and test)
+- We would heavily depend on `jest`  mocking functions:
+  - Module resolvers are not autocompleted, and if they change location our test will break. Also our IDEs cannot be smart with this (at least not by default).
+- Need to reset jest mocks every time. We can forward trash states between tests.
 
-In the project directory, you can run:
-
-### `yarn start`
-
-Runs the app in the development mode.<br />
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
-
-The page will reload if you make edits.<br />
-You will also see any lint errors in the console.
-
-### `yarn test`
-
-Launches the test runner in the interactive watch mode.<br />
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
-
-### `yarn build`
-
-Builds the app for production to the `build` folder.<br />
-It correctly bundles React in production mode and optimizes the build for the best performance.
-
-The build is minified and the filenames include the hashes.<br />
-Your app is ready to be deployed!
-
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
-
-### `yarn eject`
-
-**Note: this is a one-way operation. Once you `eject`, you can’t go back!**
-
-If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
-
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
-
-You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
-
-## Learn More
-
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
-
-To learn React, check out the [React documentation](https://reactjs.org/).
-
-### Code Splitting
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/code-splitting
-
-### Analyzing the Bundle Size
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size
-
-### Making a Progressive Web App
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app
-
-### Advanced Configuration
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/advanced-configuration
-
-### Deployment
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/deployment
-
-### `yarn build` fails to minify
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify

--- a/README.md
+++ b/README.md
@@ -1,13 +1,68 @@
-# redux-toolkit-workshop-playground
-## Exploration 1: using `useDispatch` and `useSelector` hooks.
+This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
-> Notice: only `src/components/header.js` has been migrated. Also, test for it introduced.
+## Available Scripts
 
-Some thoughts and opinions
-- This introduces the need of shadowing names, or coming up with different (but similar ones)
-- You cannot hook your HTML elements events into a useDispatch: the event param contains non-serializable properties and Redux Toolkit will drop errors in your console
-  - This could be fixed by creating a `useDispatch()` abstraction but that feels extra work to do (and test)
-- We would heavily depend on `jest`  mocking functions:
-  - Module resolvers are not autocompleted, and if they change location our test will break. Also our IDEs cannot be smart with this (at least not by default).
-- Need to reset jest mocks every time. We can forward trash states between tests.
+In the project directory, you can run:
 
+### `yarn start`
+
+Runs the app in the development mode.<br />
+Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+
+The page will reload if you make edits.<br />
+You will also see any lint errors in the console.
+
+### `yarn test`
+
+Launches the test runner in the interactive watch mode.<br />
+See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+
+### `yarn build`
+
+Builds the app for production to the `build` folder.<br />
+It correctly bundles React in production mode and optimizes the build for the best performance.
+
+The build is minified and the filenames include the hashes.<br />
+Your app is ready to be deployed!
+
+See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
+
+### `yarn eject`
+
+**Note: this is a one-way operation. Once you `eject`, you can’t go back!**
+
+If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
+
+Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
+
+You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
+
+## Learn More
+
+You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
+
+To learn React, check out the [React documentation](https://reactjs.org/).
+
+### Code Splitting
+
+This section has moved here: https://facebook.github.io/create-react-app/docs/code-splitting
+
+### Analyzing the Bundle Size
+
+This section has moved here: https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size
+
+### Making a Progressive Web App
+
+This section has moved here: https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app
+
+### Advanced Configuration
+
+This section has moved here: https://facebook.github.io/create-react-app/docs/advanced-configuration
+
+### Deployment
+
+This section has moved here: https://facebook.github.io/create-react-app/docs/deployment
+
+### `yarn build` fails to minify
+
+This section has moved here: https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # redux-toolkit-workshop-playground
-## Exploration 1:
+## Exploration 1: using `useDispatch` and `useSelector` hooks.
+
+> Notice: only `src/components/header.js` has been migrated. 
 
 Some thoughts and opinions
 - This introduces the need of shadowing names, or coming up with different (but similar ones)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # redux-toolkit-workshop-playground
 ## Exploration 1: using `useDispatch` and `useSelector` hooks.
 
-> Notice: only `src/components/header.js` has been migrated. 
+> Notice: only `src/components/header.js` has been migrated. Also, test for it introduced.
 
 Some thoughts and opinions
 - This introduces the need of shadowing names, or coming up with different (but similar ones)

--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Provider } from 'react-redux'
 
-import Header from './containers/header'
+import Header from './components/header'
 import Sidebar from './containers/sidebar'
 import Content from './containers/content'
 import Grid from './containers/layout/grid'

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -1,6 +1,9 @@
 import React from 'react'
-import PropTypes from 'prop-types'
+import { useDispatch, useSelector } from 'react-redux'
 import styled from 'styled-components'
+
+import { getDarkMode, toggleDarkMode } from '../store/ui'
+import { isLoggedIn, logout } from '../store/user'
 
 import Block from './layout/block'
 
@@ -13,23 +16,23 @@ const AppTitle = styled.h1`
   flex-grow: 1;
 `
 
-const Header = ({ darkMode, isLoggedIn, logout, toggleDarkMode }) => {
+const Header = () => {
+  const darkMode = useSelector(getDarkMode)
+  const loggedIn = useSelector(isLoggedIn)
+
+  const dispatch = useDispatch()
+  const handleLogout = () => dispatch(logout())
+  const handleToggleDarkMode = () => dispatch(toggleDarkMode())
+
   return (
     <HeaderBlock darkMode={darkMode} gridArea='header'>
       <AppTitle>Header here</AppTitle>
-      <button onClick={toggleDarkMode}>
+      <button onClick={handleToggleDarkMode}>
         Switch to {darkMode ? 'light' : 'dark'} mode
       </button>
-      {isLoggedIn && <button onClick={logout}>Logout</button>}
+      {loggedIn && <button onClick={handleLogout}>Logout</button>}
     </HeaderBlock>
   )
-}
-
-Header.propTypes = {
-  darkMode: PropTypes.bool.isRequired,
-  isLoggedIn: PropTypes.bool.isRequired,
-  logout: PropTypes.func.isRequired,
-  toggleDarkMode: PropTypes.func.isRequired,
 }
 
 export default Header

--- a/src/components/header.test.js
+++ b/src/components/header.test.js
@@ -1,0 +1,68 @@
+import React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import { getDarkMode, toggleDarkMode } from '../store/ui'
+import { isLoggedIn, logout } from '../store/user'
+
+import Header from './header'
+
+jest.mock('../store/ui')
+jest.mock('../store/user')
+
+const mockDispatch = jest.fn()
+jest.mock('react-redux', () => ({
+  useSelector: selector => selector(),
+  useDispatch: () => mockDispatch,
+}))
+
+describe('Header', () => {
+  beforeEach(() => jest.resetAllMocks())
+
+  describe('logout button', () => {
+    getDarkMode.mockResolvedValue(false)
+
+    it('should not render the logout button when not logged in', async () => {
+      render(<Header />)
+      const logoutButton = screen.queryByRole('button', { name: 'Logout' })
+      expect(logoutButton).not.toBeInTheDocument()
+    })
+
+    it('should render the logout button when logged in', async () => {
+      isLoggedIn.mockResolvedValue(true)
+      render(<Header />)
+      const logoutButton = screen.queryByRole('button', { name: 'Logout' })
+      expect(logoutButton).toBeInTheDocument()
+    })
+
+    it('clicking the logout button triggers logout action', async () => {
+      isLoggedIn.mockResolvedValue(true)
+      render(<Header />)
+      const logoutButton = screen.queryByRole('button', { name: 'Logout' })
+
+      fireEvent.click(logoutButton)
+
+      expect(mockDispatch).toHaveBeenCalledWith(logout())
+    })
+  })
+
+  describe('dark mode', function () {
+    it.each([
+      ['Switch to light mode', true],
+      ['Switch to dark mode', false],
+    ])(
+      'shows the "%s" toggle when darkMode=%s and fires the toggle action',
+      (name, darkMode) => {
+        getDarkMode.mockResolvedValue(darkMode)
+
+        render(<Header />)
+        const toggleDarkModeButton = screen.queryByRole('button')
+
+        expect(toggleDarkModeButton).toBeInTheDocument()
+
+        fireEvent.click(toggleDarkModeButton)
+
+        expect(mockDispatch).toHaveBeenCalledWith(toggleDarkMode())
+      },
+    )
+  })
+})


### PR DESCRIPTION
> Notice: only `src/components/header.js` has been migrated. Also, test for it introduced.

Some thoughts and opinions
- This introduces the need of shadowing names, or coming up with different (but similar ones)
- You cannot hook your HTML elements events into a useDispatch: the event param contains non-serializable properties and Redux Toolkit will drop errors in your console
  - This could be fixed by creating a `useDispatch()` abstraction but that feels extra work to do (and test)
- We would heavily depend on `jest`  mocking functions:
  - Module resolvers are not autocompleted, and if they change location our test will break. Also our IDEs cannot be smart with this (at least not by default).
- Need to reset jest mocks every time. We can forward trash states between tests.

